### PR TITLE
Fixed bug where error was not being cleared in the Rows() func.

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -67,10 +67,12 @@ func (r *runner) Run() error {
 }
 
 func (r *runner) Rows(v interface{}, maxRows ...int64) error {
+	// Always clear the error after we are done with Rows.
+	defer func() { r.lastErr = nil }()
+
 	// Since Query doesn't return the error directly we do it here
 	if r.lastErr != nil {
 		err := r.lastErr
-		r.lastErr = nil
 		return err
 	}
 

--- a/runner_test.go
+++ b/runner_test.go
@@ -29,3 +29,49 @@ func TestCopy(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestErrorLogging(t *testing.T) {
+	db, err := Open("postgres", "user=postgres dbname=jet sslmode=disable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.ExpandMapAndSliceMarker(true)
+	db.SetColumnConverter(SnakeCaseConverter)
+	db.SetLogger(NewLogger(nil))
+	err = db.Query(`DROP TABLE IF EXISTS "logtest"`).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = db.Query(`CREATE TABLE "logtest" ( "id" serial PRIMARY KEY , "text" text )`).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	var results []struct {
+		Id   int64
+		Text string
+	}
+	err = db.Query(`SELECT * FROM "logtest" WHERE id = $1`, 1234).Rows(&results)
+	if err != nil { // err should be nil since it was a valid query.
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Fatal("no results should be found.")
+	}
+
+	err = db.Query(`SELECT * FROM "logtest" WHERE id = $1`, "hello").Rows(&results)
+	if err == nil { // this query will procude an error.
+		t.Fatal("This should produce an error.")
+	}
+
+	err = db.Query(`SELECT * FROM "logtest" WHERE id = $1`, 5678).Rows(&results)
+	if err != nil { // r.lastErr should be clear and no error should occur.
+		t.Fatal("This should produce an error.")
+	}
+	if len(results) != 0 {
+		t.Fatal("no results should be found.")
+	}
+}


### PR DESCRIPTION
Ran into a problem where a select would cause then next query to return an error as well.
