### PR TITLE
hack: adding Exec() to query struct, exposing sql.Result

### DIFF
--- a/types.go
+++ b/types.go
@@ -5,6 +5,9 @@ import (
 )
 
 type Runnable interface {
+	// Run runs the query returning the sql.Result
+	Exec() (sql.Result, error)
+
 	// Run runs the query without returning results
 	Run() error
 	// Rows runs the query writing the rows to the specified map or struct array.


### PR DESCRIPTION
Just a hack to expose the sql.Result so we can look at LastInsertId(). #8 
