### PR TITLE
Prevent panic when aptempting closing statement if statement is nill

### DIFF
--- a/query.go
+++ b/query.go
@@ -32,7 +32,7 @@ func (q *query) Rows(v interface{}, maxRows ...int64) error {
 	// by the LRU - after we are done with Rows.
 	defer func() {
 		q.lastErr = nil
-		if q.db.LRUCache == nil {
+		if q.db.LRUCache == nil && q.stmt != nil {
 			q.stmt.Close()
 		}
 	}()


### PR DESCRIPTION
That was preventing the base SQL/mapping error to be reported.
