### PR TITLE
Add support for NULLs

### DIFF
--- a/expand.go
+++ b/expand.go
@@ -95,6 +95,10 @@ func parseHstoreColumn(s string) map[string]interface{} {
 		switch r {
 		case '\\':
 			escaped = true
+		case 'N':
+			if !quoteOpen && s[i:i+4] == "NULL" {
+				a = append(a, "NULL")
+			}
 		case '"':
 			if !escaped {
 				quoteOpen = !quoteOpen
@@ -117,10 +121,20 @@ func parseHstoreColumn(s string) map[string]interface{} {
 	// Convert to map
 	m := make(map[string]interface{}, len(a)/2)
 	lastKey := ""
+	uq := ""
+	isNull := false
 	for i, v := range a {
-		uq, _ := strconv.Unquote(v)
+		if v == "NULL" {
+			isNull = true
+		} else {
+			uq, _ = strconv.Unquote(v)
+			isNull = false
+		}
+
 		if i%2 == 0 {
 			lastKey = uq
+		} else if isNull {
+			m[lastKey] = nil
 		} else {
 			m[lastKey] = uq
 		}

--- a/expand.go
+++ b/expand.go
@@ -96,7 +96,7 @@ func parseHstoreColumn(s string) map[string]interface{} {
 		case '\\':
 			escaped = true
 		case 'N':
-			if !quoteOpen && s[i:i+4] == "NULL" {
+			if !quoteOpen && strings.HasPrefix(s[i:], "NULL") {
 				a = append(a, "NULL")
 			}
 		case '"':

--- a/expand_test.go
+++ b/expand_test.go
@@ -53,7 +53,7 @@ func TestHstoreColumnParse(t *testing.T) {
 	}
 
 	exp = "NULL"
-	if x := h["n"]; x != exp {
+	if x, ok := h["n"]; x != exp || ok != true {
 		t.Fatalf("Error: %v != %v", x, exp)
 	}
 }

--- a/expand_test.go
+++ b/expand_test.go
@@ -37,12 +37,23 @@ func TestQueryMarkSubstitution(t *testing.T) {
 }
 
 func TestHstoreColumnParse(t *testing.T) {
-	h := parseHstoreColumn(`"a\"b\"c"=>"d\"e\"f", "g\"h\"i"=>"j\"k\"l"`)
-	if x := len(h); x != 2 {
+	h := parseHstoreColumn(`"a\"b\"c"=>"d\"e\"f", "g\"h\"i"=>"j\"k\"l", "m"=>NULL, "n"=>"NULL"`)
+	if x := len(h); x != 4 {
 		t.Fatal(h)
 	}
 	t.Log(h)
+
 	if x := h[`a"b"c`]; x != `d"e"f` {
 		t.Fatal(x)
+	}
+
+	var exp interface{} = nil
+	if x := h["m"]; x != exp {
+		t.Fatalf("Error: %v != %v", x, exp)
+	}
+
+	exp = "NULL"
+	if x := h["n"]; x != exp {
+		t.Fatalf("Error: %v != %v", x, exp)
 	}
 }


### PR DESCRIPTION
Hey,

Postgres hstores allow values to be NULL, but expand.go parses these values incorrectly and panics:

```
invalid hstore map: ["hats" "notnull" "rating"]
```

This patch parses NULLs correctly.
